### PR TITLE
project 1 refactoring deep function calls

### DIFF
--- a/public/src/client/category/tools.js
+++ b/public/src/client/category/tools.js
@@ -15,13 +15,23 @@ define('forum/category/tools', [
 	CategoryTools.init = function () {
 		topicSelect.init(updateDropdownOptions);
 
-		handlePinnedTopicSort();
+		console.log('yayyy elaine');
 
+		handlePinnedTopicSort();
+		observeTopicLabelsFunc();
+		eventHandlers();
+		resetEventListeners();
+	};
+
+	function observeTopicLabelsFunc() {
 		$('[component="category/topic"]').each((index, el) => {
 			threadTools.observeTopicLabels($(el).find('[component="topic/labels"]'));
 		});
+	}
 
+	function eventHandlers() {
 		components.get('topic/delete').on('click', function () {
+			console.log('yayyy elaine');
 			categoryCommand('del', '/state', 'delete', onDeleteRestoreComplete);
 			return false;
 		});
@@ -127,7 +137,8 @@ define('forum/category/tools', [
 				tag.init(topics, ajaxify.data.tagWhitelist, onCommandComplete);
 			});
 		});
-
+	}
+	function resetEventListeners() {
 		CategoryTools.removeListeners();
 		socket.on('event:topic_deleted', setDeleteState);
 		socket.on('event:topic_restored', setDeleteState);
@@ -137,8 +148,7 @@ define('forum/category/tools', [
 		socket.on('event:topic_pinned', setPinnedState);
 		socket.on('event:topic_unpinned', setPinnedState);
 		socket.on('event:topic_moved', onTopicMoved);
-	};
-
+	}
 	function categoryCommand(method, path, command, onComplete) {
 		if (!onComplete) {
 			onComplete = function () {};
@@ -339,6 +349,5 @@ define('forum/category/tools', [
 			});
 		});
 	}
-
 	return CategoryTools;
 });


### PR DESCRIPTION
Removed SonarCloud's warning about nested functions (fixes #[447](https://github.com/CMU-313/NodeBB/issues/447) ) by creating helper functions and calling them. Tested with lint/test and manually with console logs when interacting with UI. Edited file `public/src/client/category/tools.js `

This image shows my name printed in the console on my local instance of NodeBB. Steps to trigger the print statement:
1. Log in to NodeBB as any user
2. Navigate to Categories from menu
3. Click on any of the forums (I clicked on 'announcements' in the image below)

<img width="1512" alt="Screenshot 2024-09-04 at 23 23 35" src="https://github.com/user-attachments/assets/bb39ad03-0f63-40e9-99cd-1866cd405960">



The file I refactored does not appear in the existing code coverage report. Although I attempted to write new test cases for the file, they were not compatible (`npm run lint` gave many errors), and I had no existing test cases to base my framework on. 
I believe that the reason why my file is not included in the code coverage in the first place is because it is executed when the user interacts with it on the front end. A user's configuration and actions vary. Thus, it is difficult to write automated tests and is best to test these code snippets with manual testing, as I have completed.

