### PR TITLE
Added backend api functions for to change 'resolve' status in backend

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -298,3 +298,13 @@ topicsAPI.bump = async (caller, { tid }) => {
 	await topics.markAsUnreadForAll(tid);
 	topics.pushUnreadCount(caller.uid);
 };
+
+topicsAPI.markResolved = async (caller, { tid }) => {
+	await topics.setTopicField(tid, 'resolved', true);
+	console.log("resolved pressed!")
+};
+
+topicsAPI.markUnresolved = async (caller, { tid }) => {
+	await topics.setTopicField(tid, 'unresolved', false);
+	console.log("unresolved pressed!")
+};

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -305,6 +305,6 @@ topicsAPI.markResolved = async (caller, { tid }) => {
 };
 
 topicsAPI.markUnresolved = async (caller, { tid }) => {
-	await topics.setTopicField(tid, 'unresolved', false);
+	await topics.setTopicField(tid, 'resolved', false);
 	console.log("unresolved pressed!")
 };

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -301,10 +301,10 @@ topicsAPI.bump = async (caller, { tid }) => {
 
 topicsAPI.markResolved = async (caller, { tid }) => {
 	await topics.setTopicField(tid, 'resolved', true);
-	console.log("resolved pressed!")
+	console.log('resolved pressed!');
 };
 
 topicsAPI.markUnresolved = async (caller, { tid }) => {
 	await topics.setTopicField(tid, 'resolved', false);
-	console.log("unresolved pressed!")
+	console.log('unresolved pressed!');
 };


### PR DESCRIPTION
Fixes #3 
Added two functions present in `src/api/topics.js `that change the 'resolved' field of the post in the database to true for `markResolved` and false for `markUnresolved`.
These functions should be called from the frontend when user manually presses button to toggle the 'resolved' status.
Functions are valid to be called on regardless of the current state of the 'resolved' field (ie. able to call 'markResolved' for a post whose 'resolved' field is already set to True).

Tested with printing to console, once frontend was implemented in pr #28 
![image](https://github.com/user-attachments/assets/41128b08-4d76-4e83-a475-1c0e0894a443)

Wrote automated unit tests in pr #18 to increase coverage
Note: all lint and test do pass when the last commit was made! I just accidentally re-ran it (10/9/2024) and the coveralls failed to run at all because of a configuration problem, as this is a closed issue and completed build. See the successful test and coverage report here: https://github.com/CMU-313/nodebb-f24-team-kale/actions/runs/10984399635/attempts/2

![image](https://github.com/user-attachments/assets/badc8bbd-7e20-4407-95f5-beae1f91844f)
