### PR TITLE
Add Mark Resolved/Unresolved Button to Topic View

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -74,6 +74,60 @@ define('forum/topic', [
 
 		handleTopicSearch();
 
+		const resolveButton = document.getElementById('btn-mark-resolved');
+		const unresolvedButton = document.getElementById('btn-mark-unresolved');
+		let tid = ajaxify.data.tid;
+
+		if (resolveButton && unresolvedButton) {
+			if (ajaxify.data.resolved) {
+				resolveButton.style.display = 'none';
+				unresolvedButton.style.display = 'inline-block';
+			} else {
+				unresolvedButton.style.display = 'none';
+				resolveButton.style.display = 'inline-block';
+			}
+
+			resolveButton.addEventListener('click', async function () {
+				try {
+					const response = await fetch(`/api/topics/${tid}/resolved`, {
+						method: 'PUT',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ resolved: true }),
+					});
+
+					if (response.ok) {
+						resolveButton.style.display = 'none';
+						unresolvedButton.style.display = 'inline-block';
+						console.log('Topic marked as resolved');
+					} else {
+						console.error('Failed to mark topic as resolved');
+					}
+				} catch (error) {
+					console.error('Error marking topic as resolved:', error);
+				}
+			});
+
+			unresolvedButton.addEventListener('click', async function () {
+				try {
+					const response = await fetch(`/api/topics/${tid}/resolved`, {
+						method: 'PUT',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ resolved: false }),
+					});
+
+					if (response.ok) {
+						unresolvedButton.style.display = 'none';
+						resolveButton.style.display = 'inline-block';
+						console.log('Topic marked as unresolved');
+					} else {
+						console.error('Failed to mark topic as unresolved');
+					}
+				} catch (error) {
+					console.error('Error marking topic as unresolved:', error);
+				}
+			});
+		}
+
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};
 

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,6 +14,8 @@ const authRoutes = require('./authentication');
 const writeRoutes = require('./write');
 const helpers = require('./helpers');
 
+const topicsRoutes = require('./write/topics');
+
 const { setupPageRoute } = helpers;
 
 const _mounts = {
@@ -106,6 +108,8 @@ module.exports = async function (app, middleware) {
 	router.render = function (...args) {
 		app.render(...args);
 	};
+
+	app.use('/', topicsRoutes);
 
 	// Allow plugins/themes to mount some routes elsewhere
 	const remountable = ['admin', 'categories', 'category', 'topic', 'post', 'users', 'user', 'groups', 'tags'];

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -49,5 +49,23 @@ module.exports = function () {
 	setupApiRoute(router, 'delete', '/:tid/read', [...middlewares, middleware.assert.topic], controllers.write.topics.markUnread);
 	setupApiRoute(router, 'put', '/:tid/bump', [...middlewares, middleware.assert.topic], controllers.write.topics.bump);
 
+	setupApiRoute(router, 'put', '/:tid/resolved', [...middlewares], async (req, res) => {
+		try {
+			const { tid } = req.params;
+			const { resolved } = req.body;
+
+			if (typeof resolved === 'boolean') {
+				await topics.setTopicField(tid, 'resolved', resolved);
+
+				res.json({ message: `Topic ${resolved ? 'resolved' : 'unresolved'} successfully` });
+			} else {
+				res.status(400).json({ message: 'Invalid resolved status' });
+			}
+		} catch (error) {
+			console.error('Error updating topic resolved status:', error);
+			res.status(500).json({ message: 'Error updating resolved status' });
+		}
+	});
+
 	return router;
 };


### PR DESCRIPTION
**Description**
This pull request introduces a feature that adds the buttons—Mark Resolved and Mark Unresolved—to the topic view, allowing users to toggle the resolved status of a topic.
Fixes #4

**Changes made:**
1. Added one button to the frontend template to toggle the resolved/unresolved state.
2. Integrated the buttons with the backend by adding the necessary HTML structure in the templates and set up the event listeners in the client-side JavaScript file (topic.js).
3. Styled the buttons to visually indicate the toggle between the states.
4. Added conditional logic to switch the button text and icon between "Mark as Resolved" and "Mark as Unresolved" based on the topic state.

**Limitations/Challenges:** 
Unfortunately, I was unable to fully integrate the buttons' functionality with the backend API due to several constraints:
1. The feedback on how to change the frontend came late, making it difficult to incorporate the necessary changes on time.
2. I was having difficulties connecting the backend APIs and use them in the correct JavaScript files, leading to delays.

**Next Steps**
Closing this PR due to the inability to complete full integration with the backend API.
Will continue to work on this issue in the next sprint