### PR TITLE
Resolve button: set up router for backend logic

### DIFF
--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -77,7 +77,7 @@ define('forum/topic/threadTools', [
 		topicContainer.on('click', '[component="topic/mark-resolved"]', function () {
 			var text = document.getElementById('resolve-text');
 			var isResolved = text.innerHTML === 'Mark Resolved';
-		
+
 			if (isResolved) {
 				markTopicResolved();
 				alerts.success('Topic has been marked as resolved');
@@ -159,7 +159,7 @@ define('forum/topic/threadTools', [
 		});
 
 		function markTopicResolved() {
-			const tid = ajaxify.data.tid; 
+			const tid = ajaxify.data.tid;
 			api.put(`/topics/${tid}/resolved`, {}, () => {
 				console.log('Resolved API called');
 				toggleResolve('resolved');
@@ -173,12 +173,12 @@ define('forum/topic/threadTools', [
 				toggleResolve('unresolved');
 			});
 		}
-		
+
 		// Toggle the button text and icon based on the resolved/unresolved state
 		function toggleResolve(state) {
 			var text = document.getElementById('resolve-text');
 			var icon = document.getElementById('resolve-icon');
-		
+
 			if (state === 'resolved') {
 				text.innerHTML = 'Mark Unresolved';
 				icon.className = 'fa fa-fw fa-times text-danger';

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -70,9 +70,21 @@ define('forum/topic/threadTools', [
 				} else if (ajaxify.data.category) {
 					ajaxify.go('category/' + ajaxify.data.category.slug, handleBack.onBackClicked);
 				}
-
 				alerts.success('[[topic:mark-unread.success]]');
 			});
+		});
+
+		topicContainer.on('click', '[component="topic/mark-resolved"]', function () {
+			var text = document.getElementById('resolve-text');
+			var isResolved = text.innerHTML === 'Mark Resolved';
+		
+			if (isResolved) {
+				markTopicResolved();
+				alerts.success('Topic has been marked as resolved');
+			} else {
+				markTopicUnresolved();
+				alerts.success('Topic has been marked as unresolved');
+			}
 		});
 
 		topicContainer.on('click', '[component="topic/mark-unread-for-all"]', function () {
@@ -145,6 +157,36 @@ define('forum/topic/threadTools', [
 		topicContainer.on('click', '[component="topic/ignoring"]', function () {
 			changeWatching('ignore');
 		});
+
+		function markTopicResolved() {
+			const tid = ajaxify.data.tid; 
+			api.put(`/topics/${tid}/resolved`, {}, () => {
+				console.log('Resolved API called');
+				toggleResolve('resolved');
+			});
+		}
+
+		function markTopicUnresolved() {
+			const tid = ajaxify.data.tid;
+			api.del(`/topics/${tid}/resolved`, {}, () => {
+				console.log('Unresolved API called');
+				toggleResolve('unresolved');
+			});
+		}
+		
+		// Toggle the button text and icon based on the resolved/unresolved state
+		function toggleResolve(state) {
+			var text = document.getElementById('resolve-text');
+			var icon = document.getElementById('resolve-icon');
+		
+			if (state === 'resolved') {
+				text.innerHTML = 'Mark Unresolved';
+				icon.className = 'fa fa-fw fa-times text-danger';
+			} else {
+				text.innerHTML = 'Mark Resolved';
+				icon.className = 'fa fa-fw fa-check text-success';
+			}
+		}
 
 		function changeWatching(type, state = 1) {
 			const method = state ? 'put' : 'del';

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -7,6 +7,7 @@ const topics = require('../../topics');
 const helpers = require('../helpers');
 const middleware = require('../../middleware');
 const uploadsController = require('../uploads');
+const topicsAPI = require('../../api/topics');
 
 const Topics = module.exports;
 
@@ -206,4 +207,28 @@ Topics.bump = async (req, res) => {
 	await api.topics.bump(req, { ...req.params });
 
 	helpers.formatApiResponse(200, res);
+};
+
+Topics.markResolved = async (req, res) => {
+    const tid = req.params.tid;  // Get the topic ID from the request parameters
+    try {
+        // Call the backend logic to mark the topic as resolved
+        await topicsAPI.markResolved(req.user.uid, { tid });
+        helpers.formatApiResponse(200, res, { success: true, message: 'Topic marked as resolved' });
+    } catch (err) {
+        console.error('Error marking topic as resolved:', err);
+        helpers.formatApiResponse(500, res, { success: false, error: err.message });
+    }
+};
+
+Topics.markUnresolved = async (req, res) => {
+    const tid = req.params.tid;  // Get the topic ID from the request parameters
+    try {
+        // Call the backend logic to mark the topic as unresolved
+        await topicsAPI.markUnresolved(req.user.uid, { tid });
+        helpers.formatApiResponse(200, res, { success: true, message: 'Topic marked as unresolved' });
+    } catch (err) {
+        console.error('Error marking topic as unresolved:', err);
+        helpers.formatApiResponse(500, res, { success: false, error: err.message });
+    }
 };

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -210,25 +210,23 @@ Topics.bump = async (req, res) => {
 };
 
 Topics.markResolved = async (req, res) => {
-    const tid = req.params.tid;  // Get the topic ID from the request parameters
-    try {
-        // Call the backend logic to mark the topic as resolved
-        await topicsAPI.markResolved(req.user.uid, { tid });
-        helpers.formatApiResponse(200, res, { success: true, message: 'Topic marked as resolved' });
-    } catch (err) {
-        console.error('Error marking topic as resolved:', err);
-        helpers.formatApiResponse(500, res, { success: false, error: err.message });
-    }
+	const { tid } = req.params;
+	try {
+		await topicsAPI.markResolved(req.user.uid, { tid });
+		helpers.formatApiResponse(200, res, { success: true, message: 'Topic marked as resolved' });
+	} catch (err) {
+		console.error('Error marking topic as resolved:', err);
+		helpers.formatApiResponse(500, res, { success: false, error: err.message });
+	}
 };
 
 Topics.markUnresolved = async (req, res) => {
-    const tid = req.params.tid;  // Get the topic ID from the request parameters
-    try {
-        // Call the backend logic to mark the topic as unresolved
-        await topicsAPI.markUnresolved(req.user.uid, { tid });
-        helpers.formatApiResponse(200, res, { success: true, message: 'Topic marked as unresolved' });
-    } catch (err) {
-        console.error('Error marking topic as unresolved:', err);
-        helpers.formatApiResponse(500, res, { success: false, error: err.message });
-    }
+	const { tid } = req.params;
+	try {
+		await topicsAPI.markUnresolved(req.user.uid, { tid });
+		helpers.formatApiResponse(200, res, { success: true, message: 'Topic marked as unresolved' });
+	} catch (err) {
+		console.error('Error marking topic as unresolved:', err);
+		helpers.formatApiResponse(500, res, { success: false, error: err.message });
+	}
 };

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -10,6 +10,9 @@ module.exports = function (app, middleware, controllers) {
 	const router = express.Router();
 	app.use('/api', router);
 
+	const routerV3 = express.Router();
+    app.use('/api/v3', routerV3);
+
 	router.get('/config', [...middlewares, middleware.applyCSRF], helpers.tryRoute(controllers.api.getConfig));
 
 	router.get('/self', [...middlewares], helpers.tryRoute(controllers.user.getCurrentUser));
@@ -42,4 +45,28 @@ module.exports = function (app, middleware, controllers) {
 		middleware.canViewUsers,
 		middleware.checkAccountPermissions,
 	], helpers.tryRoute(controllers.accounts.edit.uploadPicture));
+
+	routerV3.put('/topics/:tid/resolved', [...middlewares], async (req, res) => {
+        const tid = req.params.tid;
+        try {
+            await topicsAPI.markResolved(req.user.uid, { tid });
+            console.log('Topic marked as resolved');
+            res.status(200).send({ success: true });
+        } catch (err) {
+            console.error('Error marking topic as resolved:', err);
+            res.status(500).send({ error: err.message });
+        }
+    });
+
+    routerV3.delete('/topics/:tid/resolved', [...middlewares], async (req, res) => {
+        const tid = req.params.tid;
+        try {
+            await topicsAPI.markUnresolved(req.user.uid, { tid });
+            console.log('Topic marked as unresolved');
+            res.status(200).send({ success: true });
+        } catch (err) {
+            console.error('Error marking topic as unresolved:', err);
+            res.status(500).send({ error: err.message });
+        }
+    });
 };

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -10,9 +10,6 @@ module.exports = function (app, middleware, controllers) {
 	const router = express.Router();
 	app.use('/api', router);
 
-	const routerV3 = express.Router();
-    app.use('/api/v3', routerV3);
-
 	router.get('/config', [...middlewares, middleware.applyCSRF], helpers.tryRoute(controllers.api.getConfig));
 
 	router.get('/self', [...middlewares], helpers.tryRoute(controllers.user.getCurrentUser));
@@ -45,28 +42,4 @@ module.exports = function (app, middleware, controllers) {
 		middleware.canViewUsers,
 		middleware.checkAccountPermissions,
 	], helpers.tryRoute(controllers.accounts.edit.uploadPicture));
-
-	routerV3.put('/topics/:tid/resolved', [...middlewares], async (req, res) => {
-        const tid = req.params.tid;
-        try {
-            await topicsAPI.markResolved(req.user.uid, { tid });
-            console.log('Topic marked as resolved');
-            res.status(200).send({ success: true });
-        } catch (err) {
-            console.error('Error marking topic as resolved:', err);
-            res.status(500).send({ error: err.message });
-        }
-    });
-
-    routerV3.delete('/topics/:tid/resolved', [...middlewares], async (req, res) => {
-        const tid = req.params.tid;
-        try {
-            await topicsAPI.markUnresolved(req.user.uid, { tid });
-            console.log('Topic marked as unresolved');
-            res.status(200).send({ success: true });
-        } catch (err) {
-            console.error('Error marking topic as unresolved:', err);
-            res.status(500).send({ error: err.message });
-        }
-    });
 };

--- a/src/routes/write/index.js
+++ b/src/routes/write/index.js
@@ -48,6 +48,8 @@ Write.reload = async (params) => {
 
 	setupApiRoute(router, 'get', '/api/v3/ping', writeControllers.utilities.ping.get);
 	setupApiRoute(router, 'post', '/api/v3/ping', writeControllers.utilities.ping.post);
+	setupApiRoute(router, 'put', '/api/v3/topics/:tid/resolved', writeControllers.topics.markResolved);
+	setupApiRoute(router, 'delete', '/api/v3/topics/:tid/resolved', writeControllers.topics.markUnresolved);
 
 	/**
 	 * Plugins can add routes to the Write API by attaching a listener to the


### PR DESCRIPTION
**Description:**
This PR sets up the necessary API routes and implements the frontend UI for marking forum questions as resolved or unresolved. The feature allows users to toggle the resolution status of a question and displays success or error alerts accordingly.
<img width="1440" alt="Screenshot 2024-09-29 at 9 43 05 AM" src="https://github.com/user-attachments/assets/f888f4e0-9aa3-4b5a-b783-e64dc3a57303">

**Key Changes:**

1. Added new API routes to handle marking questions as resolved or unresolved:
PUT /api/v3/topics/:tid/resolved: Marks a topic as resolved.
DELETE /api/v3/topics/:tid/resolved: Marks a topic as unresolved.
Routes are defined in write/topics.js and linked to backend logic in topicsAPI.

2. Added buttons to the topic view that allow users to mark a topic as resolved or unresolved.
The buttons toggle between "Mark Resolved" and "Mark Unresolved" based on the current status of the topic.
Included success/error alert messages using app.alertSuccess and app.alertError for better user feedback.

3. Controller Logic
markResolved and markUnresolved functions added in src/controllers/write/topics.js.
These functions invoke the backend logic via topicsAPI.markResolved and topicsAPI.markUnresolved, and handle API responses and alerts.

**Testing:**
Manual testing was conducted using the following scenarios:
Successfully marking a topic as resolved.
Successfully marking a topic as unresolved.

Included console logs in the API functions to make sure that the button successfully triggered these APIs:
<img width="1440" alt="Screenshot 2024-09-29 at 9 43 27 AM" src="https://github.com/user-attachments/assets/91677774-9711-4d78-bb8d-f460a6d9a4d0">

Closes #4 