### PR TITLE
remove default anonymous field in topicsAPIs

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -50,11 +50,10 @@ topicsAPI.get = async function (caller, data) {
 	return topic;
 };
 
-topicsAPI.create = async function (caller, data, anonymous = false) {
+topicsAPI.create = async function (caller, data) {
 	if (!data) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	data.anonymous = anonymous;
 
 	const payload = { ...data };
 	payload.tags = payload.tags || [];
@@ -84,11 +83,10 @@ topicsAPI.create = async function (caller, data, anonymous = false) {
 	return result.topicData;
 };
 
-topicsAPI.reply = async function (caller, data, anonymous = false) {
+topicsAPI.reply = async function (caller, data) {
 	if (!data || !data.tid || (meta.config.minimumPostLength !== 0 && !data.content)) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	data.anonymous = anonymous;
 	const payload = { ...data };
 	apiHelpers.setDefaultPostData(caller, payload);
 


### PR DESCRIPTION
Removed the `anonymous` parameter from topic APIs in `src/api/topics.js`. The anonymous status will instead be passed in as a field in the `data` parameter. The default anonymous parameter was overwriting the anonymous data field passed in via `data`.