### PR TITLE
wrote accessor function for resolved field

### DIFF
--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -308,3 +308,13 @@ topicsAPI.markUnresolved = async (caller, { tid }) => {
 	await topics.setTopicField(tid, 'resolved', false);
 	console.log('unresolved pressed!');
 };
+
+topicsAPI.isResolved = async (caller, { tid }) => {
+	const isResolved = await topics.getTopicFields(tid, ['resolved']);
+	if (strictEqual(isResolved.resolved, 'false')){
+		return false;
+	}
+	else{
+		return true;
+	}
+};


### PR DESCRIPTION
**Description**: Added an accessor function `isResolved` into the file: src/api/topics.js. Returns the resolved field of the post, initially intended to be easier to use by the frontend. 
The changes in this file were soon overturned by pr #33 , as there was another easier way to do it. Because these changes were soon deleted, and were meant to be an easy, quick experiment for frontend, there are no unit tests for this code (nor did we need any).